### PR TITLE
Improve blog styling with nav and post cards

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -5,12 +5,22 @@
   <title>Blog - Arun Johnson</title>
   <link rel="icon" type="image/png" href="../ArunIcon_Ghibli.png">
   <link rel="stylesheet" href="../css/style.css">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
-<header>
+<header class="hero">
+  <img src="../ArunIcon_Ghibli.png" alt="Arun Johnson" class="hero-img">
   <h1>Blog</h1>
-  <nav><a href="../index.html">Home</a></nav>
+  <nav>
+    <a href="../index.html#contact">Contact</a>
+    <a href="../index.html#publications">Publications</a>
+    <a href="../index.html#work">Work</a>
+    <a href="../index.html#interests">About</a>
+    <a href="index.html">Blog</a>
+    <a href="https://t.me/s/nichromewire" target="_blank">Nichrome</a>
+  </nav>
 </header>
 <section>
   <div id="posts"></div>
@@ -26,6 +36,7 @@ fetch('posts.json')
     }
     list.forEach(item => {
       const div = document.createElement('div');
+      div.className = 'post';
       fetch(item.file)
         .then(r => r.text())
         .then(md => {

--- a/css/style.css
+++ b/css/style.css
@@ -109,3 +109,22 @@ footer {
   text-align: center;
   margin: 20px 0;
 }
+
+#posts {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.post {
+  background: #f8f9fb;
+  padding: 20px;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.post h2 {
+  margin-top: 0;
+  text-align: center;
+  color: #4b79a1;
+}


### PR DESCRIPTION
## Summary
- add FontAwesome and Google Fonts to blog
- match the main site's hero header and navigation
- style blog posts as cards with color and shadow
- keep ability to drop in Markdown files for new posts

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_68503377783083288d7e0d30c874094e