### PR TITLE
Fix blog markdown fetch path

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -44,7 +44,7 @@ fetch('posts.json')
     list.forEach(item => {
       const div = document.createElement('div');
       div.className = 'post';
-      fetch(item.file)
+      fetch(encodeURI(item.file))
         .then(r => r.text())
         .then(md => {
           md = md.replace(/!\[\[(.*?)\]\]/g, (_,p)=>`![](${encodeURI(p)})`);


### PR DESCRIPTION
## Summary
- encode blog markdown filenames when fetching them

## Testing
- `node scripts/generate_blog.js`

------
https://chatgpt.com/codex/tasks/task_e_6856daf2351483288c3b6a6a47867f37