### PR TITLE
Improve blog markdown rendering

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="purify.min.js"></script>
+  <script async id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
 <body>
 <header class="hero">
@@ -51,6 +52,9 @@ fetch('posts.json')
           md = md.replace(/\[\[([^|\]]+)\|([^\]]+)\]\]/g, '$2');
           md = md.replace(/\[\[([^\]]+)\]\]/g, '$1');
           div.innerHTML = '<h2>' + item.title + '</h2>' + DOMPurify.sanitize(marked.parse(md));
+          if (window.MathJax) {
+            MathJax.typesetPromise([div]);
+          }
         });
       document.getElementById('posts').appendChild(div);
     });

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -2,6 +2,6 @@
   {
     "title": "Biological vs. Synthetic Carbon Capture",
     "file": "Biological vs. Synthetic Carbon Capture.md",
-    "date": "2025-06-21T16:27:54.698Z"
+    "date": "2025-06-21T16:30:47.191Z"
   }
 ]

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -1,7 +1,7 @@
 [
   {
-    "title": "The Inefficiency of Trees vs. DAC",
+    "title": "Biological vs. Synthetic Carbon Capture",
     "file": "Biological vs. Synthetic Carbon Capture.md",
-    "date": "2025-06-21T16:14:54.376Z"
+    "date": "2025-06-21T16:27:54.698Z"
   }
 ]

--- a/blog/rss.xml
+++ b/blog/rss.xml
@@ -5,9 +5,9 @@
     <link>https://arunjohnson.com/blog/</link>
     <description>Updates from Arun Johnson</description>
     <item>
-      <title>The Inefficiency of Trees vs. DAC</title>
+      <title>Biological vs. Synthetic Carbon Capture</title>
       <link>https://arunjohnson.com/blog/Biological%20vs.%20Synthetic%20Carbon%20Capture.md</link>
-      <description>The Inefficiency of Trees vs. DAC</description>
+      <description>Biological vs. Synthetic Carbon Capture</description>
       <guid>Biological vs. Synthetic Carbon Capture</guid>
     </item>
   </channel>

--- a/css/style.css
+++ b/css/style.css
@@ -141,6 +141,12 @@ footer {
   color: #4b79a1;
 }
 
+.post img {
+  max-width: 100%;
+  display: block;
+  margin: 20px auto;
+}
+
 .not-found {
   text-align: center;
   margin-top: 60px;

--- a/scripts/generate_blog.js
+++ b/scripts/generate_blog.js
@@ -3,24 +3,14 @@ const path = require('path');
 
 const blogDir = path.join(__dirname, '..', 'blog');
 
-function getTitle(filename, content) {
-  const frontmatterMatch = content.match(/^---\n([\s\S]+?)\n---/);
-  if (frontmatterMatch) {
-    const titleMatch = frontmatterMatch[1].match(/^title:\s*(.*)$/m);
-    if (titleMatch) return titleMatch[1].trim();
-  }
-  // take first markdown heading
-  const headingMatch = content.match(/^\s*#{1,6}\s+(.*)$/m);
-  if (headingMatch) return headingMatch[1].trim();
-  // fallback to file name
+function getTitle(filename) {
   return filename.replace(/\.md$/i, '').replace(/[-_]/g, ' ');
 }
 
 const files = fs.readdirSync(blogDir).filter(f => f.toLowerCase().endsWith('.md'));
 const posts = files.map(f => {
   const filePath = path.join(blogDir, f);
-  const content = fs.readFileSync(filePath, 'utf8');
-  const title = getTitle(f, content);
+  const title = getTitle(f);
   const mtime = fs.statSync(filePath).mtime;
   return { title, file: f, date: mtime.toISOString() };
 }).sort((a, b) => new Date(b.date) - new Date(a.date));


### PR DESCRIPTION
## Summary
- generate blog titles from filenames instead of first headings
- size blog post images to the post width
- render LaTeX using MathJax

## Testing
- `node scripts/generate_blog.js`

------
https://chatgpt.com/codex/tasks/task_e_6856dd7aa6c88328a250e5e251dd2417