### PR TITLE
Improve work history styling and interests section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,8 +101,9 @@ footer {
 .work-item details summary::-webkit-details-marker {
   display: none;
 }
-.work-item details summary i {
-  font-size: 1.5em;
+.work-item details summary img.logo-icon {
+  width: 24px;
+  height: 24px;
   margin-right: 15px;
 }
 .work-item details ul {
@@ -155,6 +156,6 @@ footer {
 }
 
 #interests {
-  background: #2578c3;
+  background: #4b79a1;
   color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
   <ul class="work">
     <li class="work-item">
       <details>
-        <summary><i class="fas fa-graduation-cap"></i> Graduate Student, MIT Chemical Engineering <span class="date">(Aug&nbsp;2023–Present)</span></summary>
+        <summary><img src="https://logo.clearbit.com/mit.edu" alt="MIT logo" class="logo-icon"> Graduate Student, <strong>MIT Chemical Engineering</strong> <span class="date"><em>(Aug&nbsp;2023–Present)</em></span></summary>
         <ul>
           <li>Researching electrochemical systems for low-cost hydrogen in the Brushett group.</li>
         </ul>
@@ -65,7 +65,7 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><i class="fas fa-industry"></i> Chemical Engineer, Terraform Industries <span class="date">(Aug&nbsp;2022–Jul&nbsp;2023; Intern May&nbsp;2022–Aug&nbsp;2022)</span></summary>
+        <summary><img src="https://logo.clearbit.com/terraformindustries.com" alt="Terraform Industries logo" class="logo-icon"> Chemical Engineer, <strong>Terraform Industries</strong> <span class="date"><em>(May&nbsp;2022–Jul&nbsp;2023)</em></span></summary>
         <ul>
           <li>Designed Sabatier reactor producing 10 Nm³/hr methane from air-captured CO₂ and green hydrogen.</li>
           <li>Performed detailed GC analysis confirming &gt;99% CO₂ conversion.</li>
@@ -76,7 +76,7 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><i class="fas fa-flask"></i> Undergraduate Researcher (Long Lab), UC Berkeley <span class="date">(Nov&nbsp;2019–Jul&nbsp;2023)</span></summary>
+        <summary><img src="https://logo.clearbit.com/berkeley.edu" alt="UC Berkeley logo" class="logo-icon"> Undergraduate Researcher (Long Lab), <strong>UC Berkeley</strong> <span class="date"><em>(Nov&nbsp;2019–Jul&nbsp;2023)</em></span></summary>
         <ul>
           <li>Studied functionalized porous aromatic frameworks for removing arsenic and chromium from water (<a href="https://doi.org/10.1021/jacs.4c05728">paper</a>).</li>
           <li>Work spun out into <a href="https://chemfinitytech.com">ChemFinity Tech</a>.</li>
@@ -86,7 +86,7 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><i class="fas fa-leaf"></i> Vice President, UC&nbsp;Berkeley Biofuels Technology Club <span class="date">(May&nbsp;2022–May&nbsp;2023)</span></summary>
+        <summary><img src="https://logo.clearbit.com/btc.berkeley.edu" alt="Biofuels Technology Club logo" class="logo-icon"> Vice President, <strong>UC&nbsp;Berkeley Biofuels Technology Club</strong> <span class="date"><em>(May&nbsp;2022–May&nbsp;2023)</em></span></summary>
         <ul>
           <li>Organized club projects and outreach around biofuels technology.</li>
         </ul>
@@ -94,7 +94,7 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><i class="fas fa-university"></i> Research Intern (Cargnello Lab), Stanford University <span class="date">(Jun&nbsp;2018–Aug&nbsp;2019)</span></summary>
+        <summary><img src="https://logo.clearbit.com/stanford.edu" alt="Stanford University logo" class="logo-icon"> Research Intern (Cargnello Lab), <strong>Stanford University</strong> <span class="date"><em>(Jun&nbsp;2018–Aug&nbsp;2019)</em></span></summary>
         <ul>
           <li>Investigated metal nanoparticle sintering on oxide supports.</li>
           <li>Developed Si and ZrO₂ nanocapsule reactors with embedded catalysts (<a href="https://doi.org/10.1039/d0nr07960j">paper</a>).</li>


### PR DESCRIPTION
## Summary
- switch work history icons to organization logos
- italicize work dates and bold organization names
- update Terraform dates
- unify color of Interests & Background section
- reference organization logos from remote hosts instead of binaries

## Testing
- `node scripts/generate_blog.js`


------
https://chatgpt.com/codex/tasks/task_e_685cbfd5e5e083288850db48ac0ed55d