### PR TITLE
Update New Year's resolutions: ELO progress, biology pages, subtle links, and back-home styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -257,9 +257,35 @@ footer {
   color: inherit;
   text-decoration: underline;
 }
+.subtle-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted #6b8fb2;
+}
+.subtle-link:hover {
+  border-bottom-color: #4b79a1;
+}
 .back-home {
   text-align: center;
   margin: 20px 0;
+}
+.back-home a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid #d3d9e2;
+  background: #f8f9fb;
+  color: #4b79a1;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+.back-home a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 12px rgba(75, 121, 161, 0.15);
+  background: #eef3f8;
 }
 
 #posts {

--- a/new-years-resolutions.html
+++ b/new-years-resolutions.html
@@ -40,15 +40,15 @@
           <span class="resolution-meta">Current ELO: 1100</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 73%;"></div>
+          <div class="progress-fill" style="width: 18%;"></div>
         </div>
-        <p class="progress-percent">73%</p>
+        <p class="progress-percent">18%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Read/understand a biology textbook</h3>
-          <span class="resolution-meta">0 / 450 pages</span>
+          <span class="resolution-meta">0 / 1555 pages</span>
         </div>
         <div class="progress-track">
           <div class="progress-fill" style="width: 0%;"></div>
@@ -69,7 +69,7 @@
 
       <div class="resolution">
         <div class="resolution-header">
-          <h3>Reach a VO2 max of 55</h3>
+          <h3>Reach a <a class="subtle-link" href="https://en.wikipedia.org/wiki/VO2_max" target="_blank" rel="noopener noreferrer">VO2 max</a> of 55</h3>
           <span class="resolution-meta">Current: 49 (range 45–60)</span>
         </div>
         <div class="progress-track vo2-range">
@@ -85,7 +85,7 @@
 
       <div class="resolution">
         <div class="resolution-header">
-          <h3>Have 5 published long-form blog posts</h3>
+          <h3>Have 5 published <a class="subtle-link" href="https://limiting.substack.com" target="_blank" rel="noopener noreferrer">long-form blog posts</a></h3>
           <span class="resolution-meta">0 / 5 posts</span>
         </div>
         <div class="progress-track">
@@ -96,7 +96,7 @@
 
       <div class="resolution">
         <div class="resolution-header">
-          <h3>Post 20 nichrome shorts</h3>
+          <h3>Post 20 <a class="subtle-link" href="https://t.me/s/nichromewire" target="_blank" rel="noopener noreferrer">nichrome shorts</a></h3>
           <span class="resolution-meta">0 / 20 shorts</span>
         </div>
         <div class="progress-track">


### PR DESCRIPTION
### Motivation

- Make the ELO progress indicator better reflect the nonlinear difficulty of increasing rating by using a win-probability-based percentage (resulting in a lower, more principled percent). 
- Update the biology textbook target to the correct page count. 
- Turn a few plain text items into subtle links so users can jump to reference pages without adding visual noise. 
- Improve the appearance of the back-to-home affordance so it reads as a clearer interactive control.

### Description

- Updated `new-years-resolutions.html` to change the chess progress percent from `73%` to `18%` to reflect a win-chance-based mapping against an ELO 1500 opponent. 
- Changed the biology target from `450` to `1555` pages in `new-years-resolutions.html`. 
- Added subtle links (`class="subtle-link"`) to the VO2 max Wikipedia article, the long-form blog (`https://limiting.substack.com`), and the nichrome shorts feed (`https://t.me/s/nichromewire`) in `new-years-resolutions.html`. 
- Added CSS in `css/style.css` for `.subtle-link` and refactored `.back-home a` to a pill-style button with hover effects.

### Testing

- Started a local static server with `python -m http.server` and confirmed the site served successfully. 
- Captured a full-page screenshot of `/new-years-resolutions.html` using a Playwright script and saved it to the artifacts directory, which completed successfully. 
- Verified changes were staged and committed to the repository with `git`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d4416348832894381ffe5b088840)