### PR TITLE
Add CSV-driven updates for New Year's resolutions

### DIFF
--- a/new-years-resolutions.html
+++ b/new-years-resolutions.html
@@ -26,54 +26,54 @@
       <div class="resolution">
         <div class="resolution-header">
           <h3>Do 10,000 push ups</h3>
-          <span class="resolution-meta">0 / 10,000 push ups</span>
+          <span class="resolution-meta" data-field="pushups">0 / 10,000 push ups</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="pushups" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="pushups">0%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Reach ELO 1500 in chess</h3>
-          <span class="resolution-meta">Current ELO: 1100</span>
+          <span class="resolution-meta" data-field="elo">Current ELO: 1100</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 18%;"></div>
+          <div class="progress-fill" data-progress="elo" style="width: 18%;"></div>
         </div>
-        <p class="progress-percent">18%</p>
+        <p class="progress-percent" data-percent="elo">18%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Read/understand a biology textbook</h3>
-          <span class="resolution-meta">0 / 1555 pages</span>
+          <span class="resolution-meta" data-field="biology_pages">0 / 1555 pages</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="biology_pages" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="biology_pages">0%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Run 13 miles in one day</h3>
-          <span class="resolution-meta">Longest run: 0 miles</span>
+          <span class="resolution-meta" data-field="longest_run_miles">Longest run: 0 miles</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="longest_run_miles" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="longest_run_miles">0%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Reach a <a class="subtle-link" href="https://en.wikipedia.org/wiki/VO2_max" target="_blank" rel="noopener noreferrer">VO2 max</a> of 55</h3>
-          <span class="resolution-meta">Current: 49 (range 45–60)</span>
+          <span class="resolution-meta" data-field="vo2_max">Current: 49 (range 45–60)</span>
         </div>
         <div class="progress-track vo2-range">
-          <div class="progress-fill" style="width: 26.7%;"></div>
+          <div class="progress-fill" data-progress="vo2_max" style="width: 26.7%;"></div>
           <div class="progress-goal-marker" style="left: 66.7%;"></div>
         </div>
         <div class="progress-labels">
@@ -86,34 +86,34 @@
       <div class="resolution">
         <div class="resolution-header">
           <h3>Have 5 published <a class="subtle-link" href="https://limiting.substack.com" target="_blank" rel="noopener noreferrer">long-form blog posts</a></h3>
-          <span class="resolution-meta">0 / 5 posts</span>
+          <span class="resolution-meta" data-field="long_form_posts">0 / 5 posts</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="long_form_posts" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="long_form_posts">0%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Post 20 <a class="subtle-link" href="https://t.me/s/nichromewire" target="_blank" rel="noopener noreferrer">nichrome shorts</a></h3>
-          <span class="resolution-meta">0 / 20 shorts</span>
+          <span class="resolution-meta" data-field="nichrome_shorts">0 / 20 shorts</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="nichrome_shorts" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="nichrome_shorts">0%</p>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Play 10 new board games</h3>
-          <span class="resolution-meta">0 / 10 games</span>
+          <span class="resolution-meta" data-field="board_games">0 / 10 games</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="board_games" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="board_games">0%</p>
       </div>
 
       <div class="resolution">
@@ -121,23 +121,24 @@
           <h3>Go sailing</h3>
           <span class="resolution-meta">Status</span>
         </div>
-        <div class="status-badge not-done">Not yet</div>
+        <div class="status-badge not-done" data-field="sailing_done">Not yet</div>
       </div>
 
       <div class="resolution">
         <div class="resolution-header">
           <h3>Finish 10 books</h3>
-          <span class="resolution-meta">0 / 10 books</span>
+          <span class="resolution-meta" data-field="books">0 / 10 books</span>
         </div>
         <div class="progress-track">
-          <div class="progress-fill" style="width: 0%;"></div>
+          <div class="progress-fill" data-progress="books" style="width: 0%;"></div>
         </div>
-        <p class="progress-percent">0%</p>
+        <p class="progress-percent" data-percent="books">0%</p>
       </div>
     </div>
     <p class="back-home"><a href="index.html">&larr; Back to home</a></p>
   </section>
 </main>
 <footer>&copy; 2025 Arun Johnson</footer>
+<script src="scripts/new-years-resolutions.js"></script>
 </body>
 </html>

--- a/scripts/new-years-resolutions.js
+++ b/scripts/new-years-resolutions.js
@@ -1,0 +1,114 @@
+const DATA_URL = "data/new-years-resolutions.csv";
+
+const TARGETS = {
+  pushups: { goal: 10000, label: (value) => `${value} / 10,000 push ups` },
+  elo: { min: 1000, goal: 1500, label: (value) => `Current ELO: ${value}` },
+  biology_pages: { goal: 1555, label: (value) => `${value} / 1555 pages` },
+  longest_run_miles: { goal: 13, label: (value) => `Longest run: ${value} miles` },
+  vo2_max: { min: 45, goal: 55, max: 60, label: (value) => `Current: ${value} (range 45–60)` },
+  long_form_posts: { goal: 5, label: (value) => `${value} / 5 posts` },
+  nichrome_shorts: { goal: 20, label: (value) => `${value} / 20 shorts` },
+  board_games: { goal: 10, label: (value) => `${value} / 10 games` },
+  sailing_done: { label: (value) => (value ? "Done" : "Not yet") },
+  books: { goal: 10, label: (value) => `${value} / 10 books` },
+};
+
+const clamp = (value, min = 0, max = 100) => Math.min(Math.max(value, min), max);
+
+const parseCsv = (text) => {
+  const [headerLine, ...rows] = text.trim().split(/\r?\n/);
+  if (!headerLine || rows.length === 0) {
+    return null;
+  }
+  const headers = headerLine.split(",");
+  const lastRow = rows[rows.length - 1].split(",");
+  return headers.reduce((acc, header, index) => {
+    acc[header] = lastRow[index];
+    return acc;
+  }, {});
+};
+
+const toNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const toBoolean = (value) => String(value).trim().toLowerCase() === "true";
+
+const updateProgress = (field, rawValue) => {
+  const config = TARGETS[field];
+  if (!config) {
+    return;
+  }
+  const meta = document.querySelector(`[data-field="${field}"]`);
+  const progress = document.querySelector(`[data-progress="${field}"]`);
+  const percent = document.querySelector(`[data-percent="${field}"]`);
+
+  if (field === "sailing_done") {
+    updateSailingStatusBadge(rawValue);
+    return;
+  }
+
+  const value = toNumber(rawValue);
+  if (meta) {
+    meta.textContent = config.label(value);
+  }
+
+  if (field === "vo2_max") {
+    const rangeSpan = config.max - config.min;
+    const percentWidth = clamp(((value - config.min) / rangeSpan) * 100);
+    if (progress) {
+      progress.style.width = `${percentWidth.toFixed(1)}%`;
+    }
+    return;
+  }
+
+  const baseline = config.min ?? 0;
+  const percentValue = clamp(((value - baseline) / (config.goal - baseline)) * 100);
+  if (progress) {
+    progress.style.width = `${percentValue.toFixed(1)}%`;
+  }
+  if (percent) {
+    percent.textContent = `${Math.round(percentValue)}%`;
+  }
+};
+
+const updateSailingStatusBadge = (rawValue) => {
+  const badge = document.querySelector('[data-field="sailing_done"]');
+  if (!badge) {
+    return;
+  }
+  const done = toBoolean(rawValue);
+  badge.textContent = done ? "Done" : "Not yet";
+  badge.classList.toggle("done", done);
+  badge.classList.toggle("not-done", !done);
+};
+
+const loadResolutions = async () => {
+  try {
+    const response = await fetch(DATA_URL, { cache: "no-cache" });
+    if (!response.ok) {
+      throw new Error(`Failed to load CSV: ${response.status}`);
+    }
+    const text = await response.text();
+    const row = parseCsv(text);
+    if (!row) {
+      return;
+    }
+    Object.entries(row).forEach(([field, value]) => {
+      if (field === "date") {
+        return;
+      }
+      updateProgress(field, value);
+      if (field === "sailing_done") {
+        updateSailingStatusBadge(value);
+      }
+    });
+  } catch (error) {
+    console.warn("Unable to update resolutions progress:", error);
+  }
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadResolutions();
+});


### PR DESCRIPTION
### Motivation
- Wire the static resolutions page to an external data source so progress can be updated from `data/new-years-resolutions.csv`.
- Make progress visuals and labels reflect the latest recorded metrics automatically.
- Handle goals that require baselines or ranges (e.g., ELO and VO2) and a boolean status (sailing).

### Description
- Added `data-field`, `data-progress`, and `data-percent` attributes to `new-years-resolutions.html` so elements can be targeted by script.
- Added `scripts/new-years-resolutions.js` which implements `loadResolutions` to fetch the CSV, parse the latest row, and drive updates to the DOM.
- Computes percentages with configurable `min`/`goal`/`max` per field, clamps values to 0–100, and special-cases `vo2_max` range and `sailing_done` boolean badge handling.
- Injects the new script into the page via a `<script src="scripts/new-years-resolutions.js"></script>` include.

### Testing
- No automated tests were run for this change.
- The script logs a warning and fails gracefully if the CSV cannot be fetched or parsed successfully.
- Percent calculations are clamped to the 0–100 range to avoid invalid widths or labels.
- The change is static/frontend-oriented and should be verified in a browser to confirm runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958501b1c948328a25457dd7f2e05a6)