### PR TITLE
Add juggling resolution and info tooltips

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,6 +61,19 @@ nav a {
   font-weight: normal;
 }
 
+.info-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #e0e0e0;
+  color: #555;
+  font-size: 0.75em;
+  font-weight: 600;
+}
+
 .tooltiptext {
   visibility: hidden;
   width: 200px;

--- a/data/new-years-resolutions.csv
+++ b/data/new-years-resolutions.csv
@@ -1,6 +1,6 @@
-date,pushups,elo,biology_pages,longest_run_miles,vo2_max,long_form_posts,nichrome_shorts,board_games,sailing_done,books
-2025-01-01,0,1100,0,0,49,0,0,0,false,0
-2025-01-02,50,1120,44,0,49,0,1,1,false,0
-2025-01-03,90,1110,45,0,49,0,1,1,false,0
-2025-01-04,120,1102,47,0,49,0,1,2,false,0
-2025-01-05,130,1102,49,0,49,0,1,2,false,0
+date,pushups,elo,juggle_catches,biology_pages,longest_run_miles,vo2_max,long_form_posts,nichrome_shorts,board_games,sailing_done,books
+2025-01-01,0,1100,0,0,0,49,0,0,0,false,0
+2025-01-02,50,1120,0,44,0,49,0,1,1,false,0
+2025-01-03,90,1110,0,45,0,49,0,1,1,false,0
+2025-01-04,120,1102,0,47,0,49,0,1,2,false,0
+2025-01-05,130,1102,0,49,0,49,0,1,2,false,0

--- a/new-years-resolutions.html
+++ b/new-years-resolutions.html
@@ -36,13 +36,30 @@
 
       <div class="resolution">
         <div class="resolution-header">
-          <h3>Reach ELO 1500 in chess</h3>
+          <h3>
+            Reach ELO 1500 in chess
+            <span class="tooltip" aria-label="More info about the chess goal">
+              <span class="info-icon">i</span>
+              <span class="tooltiptext">As rated by Duolingo, Lichess, Chess.com, or similar from games against computers or other humans. Progress shown is 2x my current chance of winning against an ELO 1500 player.</span>
+            </span>
+          </h3>
           <span class="resolution-meta" data-field="elo">Current ELO: 1100</span>
         </div>
         <div class="progress-track">
           <div class="progress-fill" data-progress="elo" style="width: 18%;"></div>
         </div>
         <p class="progress-percent" data-percent="elo">18%</p>
+      </div>
+
+      <div class="resolution">
+        <div class="resolution-header">
+          <h3>Juggle clubs for 100 catches</h3>
+          <span class="resolution-meta" data-field="juggle_catches">0 / 100 catches</span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" data-progress="juggle_catches" style="width: 0%;"></div>
+        </div>
+        <p class="progress-percent" data-percent="juggle_catches">0%</p>
       </div>
 
       <div class="resolution">
@@ -69,7 +86,13 @@
 
       <div class="resolution">
         <div class="resolution-header">
-          <h3>Reach a <a class="subtle-link" href="https://en.wikipedia.org/wiki/VO2_max" target="_blank" rel="noopener noreferrer">VO2 max</a> of 55</h3>
+          <h3>
+            Reach a <a class="subtle-link" href="https://en.wikipedia.org/wiki/VO2_max" target="_blank" rel="noopener noreferrer">VO2 max</a> of 55
+            <span class="tooltip" aria-label="More info about the VO2 max goal">
+              <span class="info-icon">i</span>
+              <span class="tooltiptext">As reported by a Garmin watch.</span>
+            </span>
+          </h3>
           <span class="resolution-meta" data-field="vo2_max">Current: 49 (range 45–60)</span>
         </div>
         <div class="progress-track vo2-range">

--- a/scripts/new-years-resolutions.js
+++ b/scripts/new-years-resolutions.js
@@ -3,6 +3,7 @@ const DATA_URL = "data/new-years-resolutions.csv";
 const TARGETS = {
   pushups: { goal: 10000, label: (value) => `${value} / 10,000 push ups` },
   elo: { min: 1000, goal: 1500, label: (value) => `Current ELO: ${value}` },
+  juggle_catches: { goal: 100, label: (value) => `${value} / 100 catches` },
   biology_pages: { goal: 1555, label: (value) => `${value} / 1555 pages` },
   longest_run_miles: { goal: 13, label: (value) => `Longest run: ${value} miles` },
   vo2_max: { min: 45, goal: 55, max: 60, label: (value) => `Current: ${value} (range 45–60)` },


### PR DESCRIPTION
### Motivation
- Add a new, trackable juggling goal to the resolutions page so progress can be recorded alongside other metrics.
- Clarify measurement/assumptions for ambiguous goals by adding small info tooltips to the chess and VO2 max items.

### Description
- Add a `Juggle clubs for 100 catches` resolution to `new-years-resolutions.html` and wire it to a new `juggle_catches` field.
- Add `juggle_catches` to `data/new-years-resolutions.csv` and populate initial rows with `0` values.
- Register `juggle_catches` in `scripts/new-years-resolutions.js` `TARGETS` so progress bars and percent labels render correctly.
- Add tooltip markup to the chess and VO2 max headings and style the new `.info-icon` in `css/style.css` with a small grey "i" badge.

### Testing
- Started a local HTTP server with `python -m http.server 8000` and the server process started successfully.
- Ran a Playwright script to load `new-years-resolutions.html` and capture a screenshot (`artifacts/new-years-resolutions.png`) which completed successfully.
- No unit tests were added or run for this change.
- CSV parsing/display logic was exercised by the browser load during the Playwright run and showed no runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c340bef5083289e9bba01bc787ebc)