### PR TITLE
Update homepage layout: publications overlay, local work icons, remove interests

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -115,20 +115,42 @@ section {
 }
 .publications {
   display: flex;
-  flex-direction: column;
   gap: 15px;
 }
 .pub-tile {
-  background: #eee;
-  padding: 10px;
-  border-radius: 4px;
+  background: #f0f3f6;
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+  flex: 1;
+  min-height: 180px;
   text-align: center;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 .pub-tile img {
-  width: 100px;
-  height: 100px;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+  display: block;
+}
+.pub-title {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(40, 62, 81, 0.72);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  text-align: center;
+}
+.pub-tile:hover .pub-title,
+.pub-tile:focus .pub-title {
+  opacity: 1;
 }
 .icon {
   font-size: 3em;
@@ -249,17 +271,35 @@ footer {
   display: flex;
   align-items: center;
   cursor: pointer;
+  gap: 12px;
+  padding: 4px 0;
 }
 .work-item details summary::-webkit-details-marker {
   display: none;
 }
 .work-item details summary img.logo-icon {
-  width: 24px;
-  height: 24px;
-  margin-right: 15px;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: cover;
+}
+.work-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.work-title {
+  font-weight: 600;
+}
+.work-date {
+  font-size: 0.9em;
+  color: #555;
 }
 .work-item details ul {
-  margin: 5px 0 0 40px;
+  margin: 6px 0 0 46px;
+}
+.work-item details ul li + li {
+  margin-top: 4px;
 }
 .contact-icons {
   display: flex;
@@ -331,9 +371,4 @@ footer {
 .not-found {
   text-align: center;
   margin-top: 60px;
-}
-
-#interests {
-  background: #4b79a1;
-  color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -20,10 +20,9 @@
     <a href="#contact">Contact</a>
     <a href="#publications">Publications</a>
     <a href="#work">Work</a>
-    <a href="#interests">About</a>
     <a href="new-years-resolutions.html">New Year's Resolutions</a>
     <div class="dropdown">
-      <a href="#">Blog/Nichrome</a>
+      <a href="#">Blog (Nichrome)</a>
       <div class="dropdown-content">
         <a href="https://limiting.substack.com" target="_blank" rel="noopener noreferrer">Nichrome <span class="tooltip">?<span class="tooltiptext">Long form writing on limiting factors that hold back the cutting edge of technology</span></span></a>
         <a href="https://t.me/s/nichromewire" target="_blank" rel="noopener noreferrer">Nichrome Shorts <span class="tooltip">?<span class="tooltiptext">Telegram blog for science news and fun facts</span></span></a>
@@ -52,9 +51,11 @@
   <div class="publications">
     <a class="pub-tile" href="https://doi.org/10.1021/jacs.4c05728" title="Chromium &amp; Arsenic Removal">
       <img src="ChromiumArsenic_Article_Icon.png" alt="Chromium and Arsenic Removal icon" loading="lazy">
+      <span class="pub-title">Chromium &amp; Arsenic Removal</span>
     </a>
     <a class="pub-tile" href="https://doi.org/10.1039/d0nr07960j" title="Nanoparticle Coalescence">
       <img src="Nanoparticle_Article_Icon.png" alt="Nanoparticle Coalescence icon" loading="lazy">
+      <span class="pub-title">Nanoparticle Coalescence</span>
     </a>
   </div>
 </section>
@@ -63,7 +64,13 @@
   <ul class="work">
     <li class="work-item">
       <details>
-        <summary><img src="https://logo.clearbit.com/mit.edu" alt="MIT logo" class="logo-icon"> Graduate Student, <strong>MIT Chemical Engineering</strong> <span class="date"><em>(Aug&nbsp;2023–Present)</em></span></summary>
+        <summary>
+          <img src="MIT_Icon.jpg" alt="MIT logo" class="logo-icon">
+          <span class="work-text">
+            <span class="work-title">Graduate Student, <strong>MIT Chemical Engineering</strong></span>
+            <span class="work-date">Aug&nbsp;2023–Present</span>
+          </span>
+        </summary>
         <ul>
           <li>Researching electrochemical systems for low-cost hydrogen in the Brushett group.</li>
         </ul>
@@ -71,7 +78,13 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><img src="https://logo.clearbit.com/terraformindustries.com" alt="Terraform Industries logo" class="logo-icon"> Chemical Engineer, <strong>Terraform Industries</strong> <span class="date"><em>(May&nbsp;2022–Jul&nbsp;2023)</em></span></summary>
+        <summary>
+          <img src="Terraform_Icon.jpg" alt="Terraform Industries logo" class="logo-icon">
+          <span class="work-text">
+            <span class="work-title">Chemical Engineer, <strong>Terraform Industries</strong></span>
+            <span class="work-date">May&nbsp;2022–Jul&nbsp;2023</span>
+          </span>
+        </summary>
         <ul>
           <li>Designed Sabatier reactor producing 10 Nm³/hr methane from air-captured CO₂ and green hydrogen.</li>
           <li>Performed detailed GC analysis confirming &gt;99% CO₂ conversion.</li>
@@ -82,7 +95,13 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><img src="https://logo.clearbit.com/berkeley.edu" alt="UC Berkeley logo" class="logo-icon"> Undergraduate Researcher (Long Lab), <strong>UC Berkeley</strong> <span class="date"><em>(Nov&nbsp;2019–Jul&nbsp;2023)</em></span></summary>
+        <summary>
+          <img src="Berkeley_Icon.png" alt="UC Berkeley logo" class="logo-icon">
+          <span class="work-text">
+            <span class="work-title">Undergraduate Researcher (Long Lab), <strong>UC Berkeley</strong></span>
+            <span class="work-date">Nov&nbsp;2019–Jul&nbsp;2023</span>
+          </span>
+        </summary>
         <ul>
           <li>Studied functionalized porous aromatic frameworks for removing arsenic and chromium from water (<a href="https://doi.org/10.1021/jacs.4c05728">paper</a>).</li>
           <li>Work spun out into <a href="https://chemfinitytech.com">ChemFinity Tech</a>.</li>
@@ -92,7 +111,13 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><img src="https://logo.clearbit.com/btc.berkeley.edu" alt="Biofuels Technology Club logo" class="logo-icon"> Vice President, <strong>UC&nbsp;Berkeley Biofuels Technology Club</strong> <span class="date"><em>(May&nbsp;2022–May&nbsp;2023)</em></span></summary>
+        <summary>
+          <img src="Biofuels_Icon.jpg" alt="Biofuels Technology Club logo" class="logo-icon">
+          <span class="work-text">
+            <span class="work-title">Vice President, <strong>UC&nbsp;Berkeley Biofuels Technology Club</strong></span>
+            <span class="work-date">May&nbsp;2022–May&nbsp;2023</span>
+          </span>
+        </summary>
         <ul>
           <li>Organized club projects and outreach around biofuels technology.</li>
         </ul>
@@ -100,7 +125,13 @@
     </li>
     <li class="work-item">
       <details>
-        <summary><img src="https://logo.clearbit.com/stanford.edu" alt="Stanford University logo" class="logo-icon"> Research Intern (Cargnello Lab), <strong>Stanford University</strong> <span class="date"><em>(Jun&nbsp;2018–Aug&nbsp;2019)</em></span></summary>
+        <summary>
+          <img src="Stanford_Icon.jpg" alt="Stanford University logo" class="logo-icon">
+          <span class="work-text">
+            <span class="work-title">Research Intern (Cargnello Lab), <strong>Stanford University</strong></span>
+            <span class="work-date">Jun&nbsp;2018–Aug&nbsp;2019</span>
+          </span>
+        </summary>
         <ul>
           <li>Investigated metal nanoparticle sintering on oxide supports.</li>
           <li>Developed Si and ZrO₂ nanocapsule reactors with embedded catalysts (<a href="https://doi.org/10.1039/d0nr07960j">paper</a>).</li>
@@ -108,10 +139,6 @@
       </details>
     </li>
   </ul>
-</section>
-<section id="interests">
-  <h2>Interests &amp; Background</h2>
-  <p>I am part of the Brushett Research Group at MIT, where I explore electrochemical systems that can drive down the cost of green hydrogen. My background spans direct air capture and catalytic reactor design.</p>
 </section>
 </main>
 <footer>&copy; 2025 Arun Johnson</footer>


### PR DESCRIPTION
### Motivation
- Remove the redundant Interests & Background section to simplify the homepage content.
- Make academic publication tiles more visual and readable by using full-bleed images with hover-readable titles.
- Use the icon images already in the repo for the Work History entries and improve the text formatting for readability.
- Clarify the blog label in the main navigation to `Blog (Nichrome)`.

### Description
- Removed the Interests section from `index.html` and updated the nav label to `Blog (Nichrome)`.
- Reworked publications markup and CSS so `.publications` uses a side-by-side flex layout, `.pub-tile` displays full-bleed images, and added a `.pub-title` overlay that appears on hover for article titles.
- Replaced external Clearbit logo references with local icon files (e.g. `MIT_Icon.jpg`, `Terraform_Icon.jpg`, `Berkeley_Icon.png`, `Biofuels_Icon.jpg`, `Stanford_Icon.jpg`) and adjusted the markup to use new wrapper elements (`.work-text`, `.work-title`, `.work-date`) for improved spacing and typography.
- Changes applied to `index.html` and `css/style.css` to implement the above layout and styling updates.

### Testing
- Performed an automated visual smoke test by serving the site (`python -m http.server 8000`) and using Playwright to capture a homepage screenshot, which completed successfully (artifact: `artifacts/home.png`).
- No automated unit or integration tests were applicable or run for these static layout changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb902c23483288d83a09a9d124389)