### PR TITLE
Use new Chromium/Arsenic article icon and style ORCID button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -405,6 +405,27 @@ footer {
   align-items: center;
   justify-content: center;
 }
+.orcid-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: #4b79a1;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  box-shadow: 0 4px 10px rgba(40, 62, 81, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.orcid-button:hover,
+.orcid-button:focus-visible {
+  background: #3b6588;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(40, 62, 81, 0.25);
+}
 .ti-link {
   color: inherit;
   text-decoration: underline;

--- a/index.html
+++ b/index.html
@@ -47,10 +47,10 @@
 </section>
 <section id="publications">
   <h2>Academic Publications</h2>
-  <p><a href="https://orcid.org/0000-0002-5775-0430">ORCID</a></p>
+  <p><a class="orcid-button" href="https://orcid.org/0000-0002-5775-0430">ORCID</a></p>
   <div class="publications">
     <a class="pub-tile" href="https://doi.org/10.1021/jacs.4c05728" title="Chromium &amp; Arsenic Removal">
-      <img src="ChromiumArsenic_Article_Icon.png" alt="Chromium and Arsenic Removal icon" loading="lazy">
+      <img src="ChromiumArsenic_Detailed_Article_Icon.png" alt="Chromium and Arsenic Removal icon" loading="lazy">
       <span class="pub-title">Chromium &amp; Arsenic Removal</span>
     </a>
     <a class="pub-tile" href="https://doi.org/10.1039/d0nr07960j" title="Nanoparticle Coalescence">


### PR DESCRIPTION
### Motivation

- Swap the homepage publication tile to the new detailed Chromium/Arsenic article icon for the updated artwork.
- Make the ORCID link visually consistent with the site by turning it into a themed button that fits the existing color scheme and rounded styles.
- Improve hover and focus affordances so the ORCID control feels interactive and accessible.

### Description

- Replaced the publication image source in `index.html` to `ChromiumArsenic_Detailed_Article_Icon.png` for the Chromium & Arsenic Removal tile.
- Added `class="orcid-button"` to the ORCID anchor in `index.html` to apply button styles.
- Added `.orcid-button` CSS rules to `css/style.css` including padding, rounded pill shape, colors, shadow, and hover/focus-visible transitions.
- Changes affect `index.html` and `css/style.css`.

### Testing

- Served the site locally with `python -m http.server 8000` and verified `index.html` loads successfully.
- Ran a Playwright script to render the page and capture a screenshot, which completed and produced a screenshot artifact.
- No unit tests were applicable for these static front-end changes.
- Visual verification confirmed the new icon and styled ORCID button appear as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3a4cd2148328a0bfd0a3a1e3b8b5)