### PR TITLE
Link publications header to ORCID, swap Chromium/Arsenic icon, show full publication images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,7 +130,7 @@ section {
 .pub-tile img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   display: block;
 }
 .pub-title {
@@ -404,27 +404,6 @@ footer {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-.orcid-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 16px;
-  border-radius: 999px;
-  background: #4b79a1;
-  color: #fff;
-  font-weight: 600;
-  text-decoration: none;
-  letter-spacing: 0.02em;
-  box-shadow: 0 4px 10px rgba(40, 62, 81, 0.2);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.orcid-button:hover,
-.orcid-button:focus-visible {
-  background: #3b6588;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 14px rgba(40, 62, 81, 0.25);
 }
 .ti-link {
   color: inherit;

--- a/index.html
+++ b/index.html
@@ -46,11 +46,10 @@
   </p>
 </section>
 <section id="publications">
-  <h2>Academic Publications</h2>
-  <p><a class="orcid-button" href="https://orcid.org/0000-0002-5775-0430">ORCID</a></p>
+  <h2><a href="https://orcid.org/0000-0002-5775-0430">Academic Publications</a></h2>
   <div class="publications">
     <a class="pub-tile" href="https://doi.org/10.1021/jacs.4c05728" title="Chromium &amp; Arsenic Removal">
-      <img src="ChromiumArsenic_Detailed_Article_Icon.png" alt="Chromium and Arsenic Removal icon" loading="lazy">
+      <img src="ChromiumArsenic_Article_Icon.png" alt="Chromium and Arsenic Removal icon" loading="lazy">
       <span class="pub-title">Chromium &amp; Arsenic Removal</span>
     </a>
     <a class="pub-tile" href="https://doi.org/10.1039/d0nr07960j" title="Nanoparticle Coalescence">


### PR DESCRIPTION
### Motivation
- Make the "Academic Publications" heading itself a link to ORCID and remove the separate ORCID button to simplify the UI.
- Use the alternate artwork for the Chromium & Arsenic paper so the intended icon is shown.
- Ensure publication tiles display the entire image rather than a cropped portion for better legibility.

### Description
- Updated `index.html` to wrap the "Academic Publications" heading in an anchor to `https://orcid.org/0000-0002-5775-0430` and removed the standalone ORCID button markup.
- Swapped the Chromium/Arsenic publication image source from `ChromiumArsenic_Detailed_Article_Icon.png` to `ChromiumArsenic_Article_Icon.png` in `index.html`.
- Modified `css/style.css` to change `.pub-tile img` from `object-fit: cover` to `object-fit: contain` so the full image is visible inside tiles.
- Removed the `.orcid-button` CSS rules so no residual styling remains for the removed button.

### Testing
- Launched a local static server with `python -m http.server 8000` to inspect the site, and the server started successfully.
- Attempted an automated screenshot capture with Playwright to verify the publications section, but the Playwright run timed out and failed.
- No unit or CI test suite was executed for these static site changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3bf210e48328bfb441cf7dbce1a4)