### PR TITLE
Add long-term growth visuals and sync resolutions nav with main site

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -108,6 +108,8 @@ section {
   margin-bottom: 20px;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  position: relative;
+  overflow: hidden;
 }
 .profile {
   text-align: center;
@@ -438,6 +440,302 @@ footer {
   transform: translateY(-1px);
   box-shadow: 0 6px 12px rgba(75, 121, 161, 0.15);
   background: #eef3f8;
+}
+
+.growth-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.moss-tuft {
+  position: absolute;
+  width: 18px;
+  height: 12px;
+  background: radial-gradient(circle at 30% 70%, #6ca56a 0%, #4f7f4e 55%, rgba(79, 127, 78, 0) 75%);
+  border-radius: 60% 60% 40% 40%;
+  opacity: 0.85;
+  --moss-scale: 0.6;
+  transform: scale(var(--moss-scale));
+  transition: transform 2.5s ease, opacity 2.5s ease;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.15));
+  animation: moss-sway 6s ease-in-out infinite;
+}
+
+.moss-tuft.is-growing {
+  --moss-scale: 1;
+}
+
+.moss-tuft.is-expanded {
+  --moss-scale: 1.4;
+}
+
+.growth-fern {
+  position: absolute;
+  width: 22px;
+  height: 48px;
+  background: linear-gradient(160deg, #5f8b52 0%, #3e6a3d 70%);
+  border-radius: 0 0 50% 50%;
+  transform: rotate(-6deg) scale(0.85);
+  transform-origin: bottom center;
+  opacity: 0;
+  transition: opacity 2s ease, transform 2s ease;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.2));
+}
+
+.growth-fern::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 6px;
+  width: 2px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.4);
+  transform: translateX(-50%);
+  border-radius: 2px;
+}
+
+.growth-fern.is-visible {
+  opacity: 0.9;
+  transform: rotate(3deg) scale(1);
+}
+
+.growth-decay .moss-tuft,
+.growth-decay .growth-fern {
+  filter: grayscale(0.4) brightness(0.7) sepia(0.35);
+}
+
+.growth-shed .moss-tuft,
+.growth-shed .growth-fern {
+  animation: growth-fall 4s ease-in forwards;
+}
+
+.growth-ground {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 140px;
+  pointer-events: none;
+  z-index: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.growth-ground .dirt-layer {
+  width: 100%;
+  height: 0;
+  background: linear-gradient(180deg, rgba(97, 70, 45, 0.6) 0%, rgba(61, 44, 28, 0.95) 100%);
+  border-top: 2px solid rgba(60, 40, 25, 0.8);
+  transition: height 6s ease;
+}
+
+.growth-ground.is-rich .dirt-layer {
+  height: 70px;
+}
+
+.growth-ground .sprout {
+  position: absolute;
+  bottom: 50px;
+  width: 6px;
+  height: 24px;
+  background: #4a7f44;
+  border-radius: 6px;
+  opacity: 0;
+  transform: scaleY(0.2);
+  transform-origin: bottom center;
+  transition: opacity 3s ease, transform 6s ease;
+}
+
+.growth-ground .sprout::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  width: 18px;
+  height: 12px;
+  background: #5f9b4e;
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+
+.growth-ground .sprout.is-growing {
+  opacity: 0.85;
+  transform: scaleY(1);
+}
+
+.growth-ground .bush {
+  position: absolute;
+  bottom: 55px;
+  width: 50px;
+  height: 30px;
+  background: #4f7f4e;
+  border-radius: 50% 50% 40% 40%;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 4s ease, transform 6s ease;
+}
+
+.growth-ground .bush.is-grown {
+  opacity: 0.9;
+  transform: scale(1);
+}
+
+.growth-ground .tree {
+  position: absolute;
+  bottom: 55px;
+  width: 16px;
+  height: 70px;
+  background: #6b4b2e;
+  border-radius: 6px;
+  opacity: 0;
+  transform: scaleY(0.4);
+  transform-origin: bottom center;
+  transition: opacity 4s ease, transform 7s ease;
+}
+
+.growth-ground .tree::after {
+  content: "";
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  width: 80px;
+  height: 60px;
+  background: radial-gradient(circle at center, #5b8d4b 0%, #3f6d3c 70%);
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+
+.growth-ground .tree.is-grown {
+  opacity: 0.9;
+  transform: scaleY(1);
+}
+
+.growth-ground .tree.is-dead::after {
+  background: radial-gradient(circle at center, #8b6a48 0%, #5a402c 70%);
+  opacity: 0.5;
+}
+
+.growth-ground .tree.is-stump {
+  height: 30px;
+}
+
+.growth-ground .tree.is-stump::after {
+  display: none;
+}
+
+.growth-sky {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 200px;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity 6s ease;
+}
+
+.growth-sky.is-stormy {
+  opacity: 1;
+}
+
+.growth-cloud {
+  position: absolute;
+  top: 20px;
+  width: 180px;
+  height: 60px;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 50px;
+  box-shadow: 40px 10px 0 rgba(255, 255, 255, 0.7), -30px 15px 0 rgba(255, 255, 255, 0.75);
+  animation: cloud-drift 40s linear infinite;
+}
+
+.growth-rain {
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(120deg, rgba(255, 255, 255, 0.4) 0, rgba(255, 255, 255, 0.4) 2px, rgba(255, 255, 255, 0) 3px, rgba(255, 255, 255, 0) 10px);
+  opacity: 0;
+  transition: opacity 4s ease;
+  animation: rain-fall 1s linear infinite;
+}
+
+.growth-sky.is-raining .growth-rain {
+  opacity: 0.4;
+}
+
+.growth-lightning {
+  position: absolute;
+  top: 0;
+  left: 60%;
+  width: 8px;
+  height: 200px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+  opacity: 0;
+  transform: skewX(-10deg);
+}
+
+.growth-lightning.is-flashing {
+  animation: lightning-flash 2s ease;
+}
+
+@keyframes moss-sway {
+  0%,
+  100% {
+    transform: scale(var(--moss-scale)) translateY(0);
+  }
+  50% {
+    transform: scale(var(--moss-scale)) translateY(-2px);
+  }
+}
+
+@keyframes growth-fall {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(80px) scale(0.4);
+  }
+}
+
+@keyframes cloud-drift {
+  0% {
+    transform: translateX(-220px);
+  }
+  100% {
+    transform: translateX(calc(100vw + 220px));
+  }
+}
+
+@keyframes rain-fall {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 40px 80px;
+  }
+}
+
+@keyframes lightning-flash {
+  0%,
+  85%,
+  100% {
+    opacity: 0;
+  }
+  90% {
+    opacity: 1;
+  }
+  92% {
+    opacity: 0;
+  }
+  96% {
+    opacity: 0.8;
+  }
 }
 
 #posts {

--- a/css/style.css
+++ b/css/style.css
@@ -442,6 +442,42 @@ footer {
   background: #eef3f8;
 }
 
+.growth-control {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 5;
+  background: rgba(40, 62, 81, 0.88);
+  color: #fff;
+  padding: 10px 14px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(6px);
+}
+
+.growth-control__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.growth-control__value {
+  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.2);
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+
+.growth-control__slider {
+  width: 180px;
+}
+
 .growth-layer {
   position: absolute;
   inset: 0;
@@ -451,18 +487,38 @@ footer {
 
 .moss-tuft {
   position: absolute;
-  width: 18px;
-  height: 12px;
-  background: radial-gradient(circle at 30% 70%, #6ca56a 0%, #4f7f4e 55%, rgba(79, 127, 78, 0) 75%);
-  border-radius: 60% 60% 40% 40%;
-  opacity: 0.85;
+  width: 28px;
+  height: 18px;
+  background: radial-gradient(circle at 30% 80%, #7ac57b 0%, #4f8f54 48%, rgba(52, 106, 64, 0.2) 72%);
+  border-radius: 50% 50% 40% 40%;
+  opacity: 0.9;
   --moss-scale: 0.6;
   transform: scale(var(--moss-scale));
   transition: transform 2.5s ease, opacity 2.5s ease;
-  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.15));
+  filter: drop-shadow(0 3px 3px rgba(0, 0, 0, 0.18));
   animation: moss-sway 6s ease-in-out infinite;
 }
 
+.moss-tuft::before,
+.moss-tuft::after {
+  content: "";
+  position: absolute;
+  bottom: 2px;
+  width: 12px;
+  height: 16px;
+  background: radial-gradient(circle at 40% 70%, #8ad68a 0%, #4b8d50 60%, rgba(60, 120, 68, 0.2) 80%);
+  border-radius: 50% 50% 40% 40%;
+}
+
+.moss-tuft::before {
+  left: 2px;
+  transform: rotate(-8deg);
+}
+
+.moss-tuft::after {
+  right: 2px;
+  transform: rotate(12deg);
+}
 .moss-tuft.is-growing {
   --moss-scale: 1;
 }
@@ -688,7 +744,7 @@ footer {
     transform: scale(var(--moss-scale)) translateY(0);
   }
   50% {
-    transform: scale(var(--moss-scale)) translateY(-2px);
+    transform: scale(var(--moss-scale)) translateY(-3px);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -141,5 +141,6 @@
 </section>
 </main>
 <footer>&copy; 2025 Arun Johnson</footer>
+<script src="scripts/long-term-growth.js"></script>
 </body>
 </html>

--- a/new-years-resolutions.html
+++ b/new-years-resolutions.html
@@ -15,7 +15,16 @@
 <header class="hero">
   <h1>New Year's Resolutions</h1>
   <nav>
-    <a href="index.html">Home</a>
+    <a href="index.html#contact">Contact</a>
+    <a href="index.html#publications">Publications</a>
+    <a href="index.html#work">Work</a>
+    <div class="dropdown">
+      <a href="#">Blog (Nichrome)</a>
+      <div class="dropdown-content">
+        <a href="https://limiting.substack.com" target="_blank" rel="noopener noreferrer">Nichrome <span class="tooltip">?<span class="tooltiptext">Long form writing on limiting factors that hold back the cutting edge of technology</span></span></a>
+        <a href="https://t.me/s/nichromewire" target="_blank" rel="noopener noreferrer">Nichrome Shorts <span class="tooltip">?<span class="tooltiptext">Telegram blog for science news and fun facts</span></span></a>
+      </div>
+    </div>
   </nav>
 </header>
 <main>
@@ -284,5 +293,6 @@
 </main>
 <footer>&copy; 2025 Arun Johnson</footer>
 <script src="scripts/new-years-resolutions.js"></script>
+<script src="scripts/long-term-growth.js"></script>
 </body>
 </html>

--- a/scripts/long-term-growth.js
+++ b/scripts/long-term-growth.js
@@ -1,0 +1,205 @@
+const GROWTH_STAGES = [
+  { delay: 2 * 60 * 1000, action: seedMoss },
+  { delay: 3 * 60 * 1000, action: expandMoss },
+  { delay: 10 * 60 * 1000, action: addFerns },
+  { delay: 20 * 60 * 1000, action: startDecay },
+  { delay: 24 * 60 * 1000, action: shedGrowth },
+  { delay: 26 * 60 * 1000, action: buildDirt },
+  { delay: 30 * 60 * 1000, action: sproutPlants },
+  { delay: 38 * 60 * 1000, action: growTrees },
+  { delay: 45 * 60 * 1000, action: startWeather },
+  { delay: 48 * 60 * 1000, action: lightningStrike }
+];
+
+const growthState = {
+  containers: [],
+  mossTufts: [],
+  ferns: [],
+  ground: null,
+  tree: null,
+  sky: null,
+  lightning: null
+};
+
+function scheduleGrowth() {
+  GROWTH_STAGES.forEach(({ delay, action }) => {
+    window.setTimeout(action, delay);
+  });
+}
+
+function getContainers() {
+  return Array.from(document.querySelectorAll('main section, .resolution, .post'));
+}
+
+function ensureGrowthLayer(container) {
+  let layer = container.querySelector('.growth-layer');
+  if (!layer) {
+    layer = document.createElement('div');
+    layer.className = 'growth-layer';
+    container.appendChild(layer);
+  }
+  return layer;
+}
+
+function createMossTuft(layer, options = {}) {
+  const tuft = document.createElement('span');
+  tuft.className = 'moss-tuft';
+  const side = options.side ?? (Math.random() > 0.5 ? 'left' : 'right');
+  const top = options.top ?? Math.floor(Math.random() * 80 + 8);
+  const offset = options.offset ?? Math.floor(Math.random() * 6 + 2);
+  tuft.style.top = `${top}%`;
+  if (side === 'left') {
+    tuft.style.left = `${offset}px`;
+  } else {
+    tuft.style.right = `${offset}px`;
+  }
+  layer.appendChild(tuft);
+  requestAnimationFrame(() => {
+    tuft.classList.add('is-growing');
+  });
+  growthState.mossTufts.push(tuft);
+}
+
+function seedMoss() {
+  growthState.containers = getContainers();
+  growthState.containers.forEach((container) => {
+    const layer = ensureGrowthLayer(container);
+    createMossTuft(layer, { side: 'left', top: 18 });
+    createMossTuft(layer, { side: 'right', top: 28 });
+  });
+}
+
+function expandMoss() {
+  growthState.mossTufts.forEach((tuft) => tuft.classList.add('is-expanded'));
+  growthState.containers.forEach((container) => {
+    const layer = ensureGrowthLayer(container);
+    createMossTuft(layer);
+  });
+}
+
+function addFerns() {
+  growthState.containers.forEach((container) => {
+    const layer = ensureGrowthLayer(container);
+    const fern = document.createElement('span');
+    fern.className = 'growth-fern';
+    fern.style.bottom = `${Math.floor(Math.random() * 16 + 6)}px`;
+    fern.style.left = `${Math.floor(Math.random() * 15 + 6)}px`;
+    if (Math.random() > 0.5) {
+      fern.style.left = 'auto';
+      fern.style.right = `${Math.floor(Math.random() * 15 + 6)}px`;
+    }
+    layer.appendChild(fern);
+    requestAnimationFrame(() => {
+      fern.classList.add('is-visible');
+    });
+    growthState.ferns.push(fern);
+  });
+}
+
+function startDecay() {
+  document.body.classList.add('growth-decay');
+}
+
+function shedGrowth() {
+  document.body.classList.add('growth-shed');
+}
+
+function buildDirt() {
+  if (growthState.ground) {
+    growthState.ground.classList.add('is-rich');
+    return;
+  }
+  const ground = document.createElement('div');
+  ground.className = 'growth-ground';
+  const dirt = document.createElement('div');
+  dirt.className = 'dirt-layer';
+  ground.appendChild(dirt);
+  document.body.appendChild(ground);
+  growthState.ground = ground;
+  requestAnimationFrame(() => {
+    ground.classList.add('is-rich');
+  });
+}
+
+function sproutPlants() {
+  if (!growthState.ground) {
+    buildDirt();
+  }
+  const positions = [20, 45, 70];
+  positions.forEach((left) => {
+    const sprout = document.createElement('span');
+    sprout.className = 'sprout';
+    sprout.style.left = `${left}%`;
+    growthState.ground.appendChild(sprout);
+    requestAnimationFrame(() => {
+      sprout.classList.add('is-growing');
+    });
+  });
+
+  const bush = document.createElement('span');
+  bush.className = 'bush';
+  bush.style.left = '60%';
+  growthState.ground.appendChild(bush);
+  requestAnimationFrame(() => bush.classList.add('is-grown'));
+}
+
+function growTrees() {
+  if (!growthState.ground) {
+    buildDirt();
+  }
+  const tree = document.createElement('span');
+  tree.className = 'tree';
+  tree.style.left = '80%';
+  growthState.ground.appendChild(tree);
+  requestAnimationFrame(() => tree.classList.add('is-grown'));
+  growthState.tree = tree;
+}
+
+function startWeather() {
+  if (growthState.sky) {
+    growthState.sky.classList.add('is-stormy', 'is-raining');
+    return;
+  }
+  const sky = document.createElement('div');
+  sky.className = 'growth-sky';
+  const cloud = document.createElement('div');
+  cloud.className = 'growth-cloud';
+  cloud.style.top = '20px';
+  const cloud2 = document.createElement('div');
+  cloud2.className = 'growth-cloud';
+  cloud2.style.top = '80px';
+  cloud2.style.animationDelay = '10s';
+  const rain = document.createElement('div');
+  rain.className = 'growth-rain';
+  const lightning = document.createElement('div');
+  lightning.className = 'growth-lightning';
+  sky.appendChild(cloud);
+  sky.appendChild(cloud2);
+  sky.appendChild(rain);
+  sky.appendChild(lightning);
+  document.body.appendChild(sky);
+  growthState.sky = sky;
+  growthState.lightning = lightning;
+  requestAnimationFrame(() => {
+    sky.classList.add('is-stormy', 'is-raining');
+  });
+}
+
+function lightningStrike() {
+  if (!growthState.sky) {
+    startWeather();
+  }
+  if (growthState.lightning) {
+    growthState.lightning.classList.add('is-flashing');
+  }
+  if (growthState.tree) {
+    growthState.tree.classList.add('is-dead');
+    window.setTimeout(() => {
+      growthState.tree.classList.add('is-stump');
+    }, 2 * 60 * 1000);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  scheduleGrowth();
+});


### PR DESCRIPTION
### Motivation
- Make the New Year's resolutions page navigation match the home page sections so users can jump to the same anchors easily.  
- Add a long-lived, time-driven visual feature so the site visually "ages" over long page-open sessions with moss, ferns, dirt, plants and weather.  
- Encapsulate growth visuals in CSS/JS so the effect is non-destructive and toggled by a single script.  
- Keep the visual additions lightweight and purely client-side so the static site is unchanged on the server.

### Description
- Updated `new-years-resolutions.html` navigation to include `index.html#contact`, `index.html#publications`, `index.html#work` and the same blog dropdown used on the main page.  
- Added `scripts/long-term-growth.js` and included it on both `index.html` and `new-years-resolutions.html` to schedule timed growth stages that manipulate the DOM (seed moss, expand, add ferns, decay, build dirt, sprout plants, grow trees, start weather, and trigger lightning).  
- Extended `css/style.css` with layout support (`position: relative; overflow: hidden;` on `section`) and a comprehensive set of styles/animations for `.growth-layer`, `.moss-tuft`, `.growth-fern`, `.growth-ground`, `.growth-sky`, and related keyframes.  
- Minor CSS improvements include using a `--moss-scale` custom property for smoother moss scaling transitions.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and used a Playwright script to load `http://127.0.0.1:8000/new-years-resolutions.html` and capture a screenshot, which completed successfully and produced `artifacts/new-years-resolutions.png`.  
- No unit tests were added or run since these are static UI/visual changes and the behavior is time-driven in the browser.  
- Verified that the new script is included in both `index.html` and `new-years-resolutions.html` and that CSS selectors are present via inspection.  
- All automated steps executed during the rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628d364da88328901d55a815d9282b)