### PR TITLE
Sort NYR resolutions by completion percent

### DIFF
--- a/scripts/new-years-resolutions.js
+++ b/scripts/new-years-resolutions.js
@@ -39,6 +39,23 @@ const toNumber = (value) => {
 
 const toBoolean = (value) => String(value).trim().toLowerCase() === "true";
 
+const getCompletionPercent = (field, rawValue) => {
+  const config = TARGETS[field];
+  if (!config) {
+    return 0;
+  }
+  if (field === "sailing_done") {
+    return toBoolean(rawValue) ? 100 : 0;
+  }
+  const value = toNumber(rawValue);
+  if (field === "vo2_max") {
+    const rangeSpan = config.max - config.min;
+    return clamp(((value - config.min) / rangeSpan) * 100);
+  }
+  const baseline = config.min ?? 0;
+  return clamp(((value - baseline) / (config.goal - baseline)) * 100);
+};
+
 const updateProgress = (field, rawValue) => {
   const config = TARGETS[field];
   if (!config) {
@@ -185,6 +202,27 @@ const setupGraphToggles = () => {
   });
 };
 
+const sortResolutionsByCompletion = (latestRow) => {
+  const container = document.querySelector(".resolutions");
+  if (!container || !latestRow) {
+    return;
+  }
+
+  const cards = Array.from(container.querySelectorAll(":scope > .resolution"));
+  const rankedCards = cards.map((card, index) => {
+    const field =
+      card.querySelector("[data-progress]")?.dataset.progress ||
+      card.querySelector("[data-percent]")?.dataset.percent ||
+      card.querySelector("[data-field]")?.dataset.field;
+    const completion = field ? getCompletionPercent(field, latestRow[field]) : 0;
+    return { card, index, completion };
+  });
+
+  rankedCards
+    .sort((a, b) => b.completion - a.completion || a.index - b.index)
+    .forEach(({ card }) => container.appendChild(card));
+};
+
 const loadResolutions = async () => {
   try {
     const response = await fetch(DATA_URL, { cache: "no-cache" });
@@ -206,6 +244,7 @@ const loadResolutions = async () => {
         updateSailingStatusBadge(value);
       }
     });
+    sortResolutionsByCompletion(latestRow);
     buildGraphs(parsed.rows);
   } catch (error) {
     console.warn("Unable to update resolutions progress:", error);


### PR DESCRIPTION
### Motivation
- Resolutions on the New Year's page should be ordered by how close they are to completion so the most-progressed goals appear first while leaving visual styling unchanged.

### Description
- Added `getCompletionPercent(field, rawValue)` to `scripts/new-years-resolutions.js` to normalize completion into a comparable percentage with special handling for `vo2_max` ranges and boolean `sailing_done`.
- Added `sortResolutionsByCompletion(latestRow)` which collects `.resolution` cards, computes completion using the helper, and reorders cards in descending completion while preserving original order for ties.
- Invoke sorting from `loadResolutions` immediately after applying values from the latest CSV row so UI visuals and progress indicators remain the same.

### Testing
- Ran `node --check scripts/new-years-resolutions.js` to validate syntax and it completed successfully.
- Served the site and ran an automated Playwright load + screenshot (page `http://127.0.0.1:4173/new-years-resolutions.html`, output `artifacts/nyr-sorted.png`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7781b97bc83289d220b28e80a88c9)