### PR TITLE
Revamp homepage into Typeform-style interactive Q&A flow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -471,3 +471,148 @@ footer {
   text-align: center;
   margin-top: 60px;
 }
+
+/* Interactive Q&A homepage revamp */
+body.home-qa {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', sans-serif;
+  background: radial-gradient(circle at top, #17223a 0%, #0a0f1c 55%, #080b14 100%);
+  color: #e8eefc;
+}
+
+.home-qa .qa-shell {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 40px 20px 32px;
+  display: grid;
+  gap: 24px;
+}
+
+.home-qa .profile-card,
+.home-qa .qa-card {
+  background: rgba(14, 22, 40, 0.88);
+  border: 1px solid rgba(88, 146, 255, 0.25);
+  border-radius: 18px;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.38);
+}
+
+.home-qa .profile-card {
+  text-align: center;
+  padding: 28px 24px;
+}
+
+.home-qa .profile-image {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  border: 3px solid #4f8dff;
+}
+
+.home-qa h1,
+.home-qa h2 {
+  margin: 12px 0 8px;
+}
+
+.home-qa .profile-card p,
+.home-qa .qa-subtitle,
+.home-qa .free-note {
+  color: #b9c8ec;
+}
+
+.home-qa .qa-card {
+  padding: 26px 22px;
+}
+
+.home-qa .qa-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin: 16px 0;
+}
+
+.home-qa .qa-option {
+  border: 1px solid rgba(111, 162, 255, 0.35);
+  background: #111c32;
+  color: #e8eefc;
+  border-radius: 12px;
+  padding: 12px 14px;
+  text-align: left;
+  font-size: 1rem;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  cursor: pointer;
+}
+
+.home-qa .qa-option:hover,
+.home-qa .qa-option.active {
+  background: #17315f;
+  border-color: #67a2ff;
+}
+
+.home-qa .qa-label {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: #2b4f8b;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.home-qa .qa-answer {
+  margin: 14px 0 18px;
+  padding: 14px;
+  border-radius: 10px;
+  background: #0d162b;
+  border: 1px solid rgba(88, 146, 255, 0.2);
+}
+
+.home-qa .free-label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.home-qa .free-row {
+  display: flex;
+  gap: 8px;
+}
+
+.home-qa #free-question {
+  flex: 1;
+  border: 1px solid rgba(111, 162, 255, 0.35);
+  background: #0e182d;
+  color: #fff;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.home-qa #send-question {
+  width: 46px;
+  border: 1px solid #67a2ff;
+  background: linear-gradient(135deg, #2b62cc, #1f4fa8);
+  color: #fff;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.home-qa .secondary-links {
+  text-align: center;
+  opacity: 0.82;
+}
+
+.home-qa .secondary-links a {
+  color: #9bbcff;
+  font-size: 0.95rem;
+  text-decoration: none;
+  margin: 0 10px;
+}
+
+@media (max-width: 640px) {
+  .home-qa .qa-shell {
+    padding: 22px 14px;
+  }
+}

--- a/data/qa.json
+++ b/data/qa.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "A",
+    "question": "What are you currently focused on?",
+    "answer": "I’m a graduate student in Chemical Engineering at MIT, focused on electrochemical systems that can reduce the cost of green hydrogen production by an order of magnitude."
+  },
+  {
+    "id": "B",
+    "question": "What did you work on before MIT?",
+    "answer": "Before MIT, I worked on carbon-neutral synthetic fuel at Terraform Industries and conducted materials research at Berkeley and Stanford."
+  },
+  {
+    "id": "C",
+    "question": "What kinds of topics do you write about?",
+    "answer": "I write about science and technology bottlenecks, practical engineering constraints, and the limiting factors that shape real-world progress."
+  },
+  {
+    "id": "D",
+    "question": "What’s the best way to reach you?",
+    "answer": "The fastest path is usually Telegram, followed by email and LinkedIn."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -5,141 +5,49 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Arun Johnson – chemical engineer working on green hydrogen.">
   <meta property="og:title" content="Arun Johnson">
-  <meta property="og:description" content="Chemical engineer working on 10x cheaper systems for green hydrogen production.">
-  <title>Arun Johnson</title>
+  <meta property="og:description" content="Ask Arun questions about his work, writing, and background.">
+  <title>Arun Johnson | Interactive Q&A</title>
   <link rel="icon" type="image/png" href="ArunIcon_Basalt.png">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap">
-  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
-<header class="hero">
-  <img src="ArunIcon_Basalt.png" alt="Arun Johnson" class="hero-img" loading="lazy">
-  <h1>Arun Johnson</h1>
-  <nav>
-    <a href="#contact">Contact</a>
-    <a href="#publications">Publications</a>
-    <a href="#work">Work</a>
-    <a href="new-years-resolutions.html">New Year's Resolutions</a>
-    <div class="dropdown">
-      <a href="#">Blog (Nichrome)</a>
-      <div class="dropdown-content">
-        <a href="https://limiting.substack.com" target="_blank" rel="noopener noreferrer">Nichrome <span class="tooltip">?<span class="tooltiptext">Long form writing on limiting factors that hold back the cutting edge of technology</span></span></a>
-        <a href="https://t.me/s/nichromewire" target="_blank" rel="noopener noreferrer">Nichrome Shorts <span class="tooltip">?<span class="tooltiptext">Telegram blog for science news and fun facts</span></span></a>
+<body class="home-qa">
+  <main class="qa-shell">
+    <section class="profile-card">
+      <img src="ArunIcon_Basalt.png" alt="Arun Johnson" class="profile-image" loading="lazy">
+      <h1>Arun Johnson</h1>
+      <p>Graduate student in Chemical Engineering at MIT building 10x cheaper systems for green hydrogen. Previously at Terraform Industries, Berkeley, and Stanford.</p>
+    </section>
+
+    <section class="qa-card" aria-label="Interactive questions">
+      <h2>Ask me anything</h2>
+      <p class="qa-subtitle">Choose a starter question or send your own.</p>
+
+      <div id="qa-options" class="qa-options" aria-label="Question options"></div>
+
+      <div id="qa-answer" class="qa-answer" aria-live="polite">
+        <p>Select A, B, C, or D to see an instant answer.</p>
       </div>
-    </div>
-  </nav>
-</header>
-<main>
-<section class="profile">
-  <p>Graduate student in Chemical Engineering at MIT developing 10x cheaper systems for green hydrogen production.<br><br>Previously worked on carbon-neutral synthetic fuel at <a href="https://terraformindustries.com" class="ti-link">Terraform Industries</a> and materials research at Berkeley and Stanford.</p>
-</section>
-<section class="contact" id="contact">
-  <h2>Get in touch with me!</h2>
-  <p class="sub">You can use any of these methods, in order of preference</p>
-  <p class="contact-icons">
-    <a href="https://t.me/arunsjohnson" class="icon" aria-label="Telegram"><i class="fab fa-telegram"></i></a>
-    <span class="arrow">&gt;</span>
-    <a href="mailto:arun2642@gmail.com" class="icon" aria-label="Email"><i class="fas fa-envelope"></i></a>
-    <span class="arrow">&gt;</span>
-    <a href="https://www.linkedin.com/in/arunsjohnson/" class="icon" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
-  </p>
-</section>
-<section id="publications">
-  <h2><a href="https://orcid.org/0000-0002-5775-0430">Academic Publications</a></h2>
-  <div class="publications">
-    <a class="pub-tile" href="https://doi.org/10.1021/jacs.4c05728" title="Chromium &amp; Arsenic Removal">
-      <img src="ChromiumArsenic_Article_Icon.png" alt="Chromium and Arsenic Removal icon" loading="lazy">
-      <span class="pub-title">Chromium &amp; Arsenic Removal</span>
-    </a>
-    <a class="pub-tile" href="https://doi.org/10.1039/d0nr07960j" title="Nanoparticle Coalescence">
-      <img src="Nanoparticle_Article_Icon.png" alt="Nanoparticle Coalescence icon" loading="lazy">
-      <span class="pub-title">Nanoparticle Coalescence</span>
-    </a>
-  </div>
-</section>
-<section id="work">
-  <h2>Work History</h2>
-  <ul class="work">
-    <li class="work-item">
-      <details>
-        <summary>
-          <img src="MIT_Icon.jpg" alt="MIT logo" class="logo-icon">
-          <span class="work-text">
-            <span class="work-title">Graduate Student, <strong>MIT Chemical Engineering</strong></span>
-            <span class="work-date">Aug&nbsp;2023–Present</span>
-          </span>
-        </summary>
-        <ul>
-          <li>Researching electrochemical systems for low-cost hydrogen in the Brushett group.</li>
-        </ul>
-      </details>
-    </li>
-    <li class="work-item">
-      <details>
-        <summary>
-          <img src="Terraform_Icon.jpg" alt="Terraform Industries logo" class="logo-icon">
-          <span class="work-text">
-            <span class="work-title">Chemical Engineer, <strong>Terraform Industries</strong></span>
-            <span class="work-date">May&nbsp;2022–Jul&nbsp;2023</span>
-          </span>
-        </summary>
-        <ul>
-          <li>Designed Sabatier reactor producing 10 Nm³/hr methane from air-captured CO₂ and green hydrogen.</li>
-          <li>Performed detailed GC analysis confirming &gt;99% CO₂ conversion.</li>
-          <li>Developed kinetic and thermodynamic models for reactor design.</li>
-          <li>Supported recruiting, investor outreach and business development.</li>
-        </ul>
-      </details>
-    </li>
-    <li class="work-item">
-      <details>
-        <summary>
-          <img src="Berkeley_Icon.png" alt="UC Berkeley logo" class="logo-icon">
-          <span class="work-text">
-            <span class="work-title">Undergraduate Researcher (Long Lab), <strong>UC Berkeley</strong></span>
-            <span class="work-date">Nov&nbsp;2019–Jul&nbsp;2023</span>
-          </span>
-        </summary>
-        <ul>
-          <li>Studied functionalized porous aromatic frameworks for removing arsenic and chromium from water (<a href="https://doi.org/10.1021/jacs.4c05728">paper</a>).</li>
-          <li>Work spun out into <a href="https://chemfinitytech.com">ChemFinity Tech</a>.</li>
-          <li>Combined experimental and computational approaches.</li>
-        </ul>
-      </details>
-    </li>
-    <li class="work-item">
-      <details>
-        <summary>
-          <img src="Biofuels_Icon.jpg" alt="Biofuels Technology Club logo" class="logo-icon">
-          <span class="work-text">
-            <span class="work-title">Vice President, <strong>UC&nbsp;Berkeley Biofuels Technology Club</strong></span>
-            <span class="work-date">May&nbsp;2022–May&nbsp;2023</span>
-          </span>
-        </summary>
-        <ul>
-          <li>Organized club projects and outreach around biofuels technology.</li>
-        </ul>
-      </details>
-    </li>
-    <li class="work-item">
-      <details>
-        <summary>
-          <img src="Stanford_Icon.jpg" alt="Stanford University logo" class="logo-icon">
-          <span class="work-text">
-            <span class="work-title">Research Intern (Cargnello Lab), <strong>Stanford University</strong></span>
-            <span class="work-date">Jun&nbsp;2018–Aug&nbsp;2019</span>
-          </span>
-        </summary>
-        <ul>
-          <li>Investigated metal nanoparticle sintering on oxide supports.</li>
-          <li>Developed Si and ZrO₂ nanocapsule reactors with embedded catalysts (<a href="https://doi.org/10.1039/d0nr07960j">paper</a>).</li>
-        </ul>
-      </details>
-    </li>
-  </ul>
-</section>
-</main>
-<footer>&copy; 2025 Arun Johnson</footer>
+
+      <label for="free-question" class="free-label">Ask a new question</label>
+      <div class="free-row">
+        <input id="free-question" type="text" placeholder="Type your question and press Enter" autocomplete="off">
+        <button id="send-question" type="button" aria-label="Send question">
+          <i class="fa-solid fa-paper-plane"></i>
+        </button>
+      </div>
+      <p class="free-note">Your custom question opens as a draft email to me.</p>
+    </section>
+
+    <nav class="secondary-links" aria-label="Additional pages">
+      <a href="blog/index.html">Blog</a>
+      <a href="new-years-resolutions.html">New Year’s Resolutions</a>
+      <a href="mailto:arun2642@gmail.com">Contact</a>
+      <a href="https://orcid.org/0000-0002-5775-0430" target="_blank" rel="noopener noreferrer">Publications</a>
+    </nav>
+  </main>
+
+  <script src="scripts/qa.js"></script>
 </body>
 </html>

--- a/scripts/qa.js
+++ b/scripts/qa.js
@@ -1,0 +1,62 @@
+async function loadQA() {
+  const response = await fetch('data/qa.json');
+  if (!response.ok) {
+    throw new Error('Failed to load Q&A content.');
+  }
+  return response.json();
+}
+
+function renderQA(items) {
+  const container = document.getElementById('qa-options');
+  const answerBox = document.getElementById('qa-answer');
+
+  items.forEach((item) => {
+    const button = document.createElement('button');
+    button.className = 'qa-option';
+    button.type = 'button';
+    button.innerHTML = `<span class="qa-label">${item.id}</span><span>${item.question}</span>`;
+    button.addEventListener('click', () => {
+      answerBox.innerHTML = `<h3>${item.id}. ${item.question}</h3><p>${item.answer}</p>`;
+      document.querySelectorAll('.qa-option').forEach((opt) => opt.classList.remove('active'));
+      button.classList.add('active');
+    });
+    container.appendChild(button);
+  });
+}
+
+function openDraftEmail() {
+  const input = document.getElementById('free-question');
+  const question = input.value.trim();
+
+  if (!question) return;
+
+  const subject = encodeURIComponent('Website Q&A Question');
+  const body = encodeURIComponent(`Hi Arun,\n\nI have a question from your website:\n\n${question}\n\nThanks!`);
+  window.location.href = `mailto:arun2642@gmail.com?subject=${subject}&body=${body}`;
+  input.value = '';
+}
+
+function initFreeResponse() {
+  const input = document.getElementById('free-question');
+  const sendBtn = document.getElementById('send-question');
+
+  sendBtn.addEventListener('click', openDraftEmail);
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      openDraftEmail();
+    }
+  });
+}
+
+(async function init() {
+  try {
+    const items = await loadQA();
+    renderQA(items);
+  } catch (error) {
+    const answerBox = document.getElementById('qa-answer');
+    answerBox.innerHTML = '<p>Sorry—Q&A content is temporarily unavailable.</p>';
+  }
+
+  initFreeResponse();
+})();


### PR DESCRIPTION
### Motivation
- Replace the static homepage with a focused, interactive Q&A-first experience that foregrounds the profile image and short bio.  
- Adopt a dark, Typeform-inspired visual style with blue accents while keeping existing pages (blog, contact, resolutions, publications) available but de-emphasized.  
- Implement stage-1 behavior using a static JSON data source so later backend/semantic-search/LLM integrations can plug into the same shell.

### Description
- Added a new Q&A-centric homepage layout in `index.html` scoped under `body.home-qa` including a profile card, a selectable A/B/C/D question list, an inline answer area, and a free-response input with an icon-only send button.  
- Introduced `data/qa.json` to hold the stage-1 Q&A payload (4 starter items: A/B/C/D) and made the page load these programmatically.  
- Implemented front-end logic in `scripts/qa.js` to `fetch` the JSON, render question option buttons, display answers inline when selected, and open a prefilled `mailto:` draft when a user submits the free-response (Enter key or paper-plane icon).  
- Added dark-mode, Typeform-style CSS rules to `css/style.css` scoped to `body.home-qa`, and left secondary navigation links pointing to non-home pages so they are available but visually deemphasized.

### Testing
- Verified files were written and committed successfully via `git commit` which completed without error.  
- Performed automated repository/file checks (file listings and `nl` content dumps) to confirm `index.html`, `css/style.css`, `scripts/qa.js`, and `data/qa.json` contain the expected changes and content.  
- Created PR metadata with `make_pr` which produced the PR title/body payload successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0797f5a0c88328a1ece0246eb9b8de)